### PR TITLE
Avoid call ResourceBarrier with 0 Barriers

### DIFF
--- a/MiniEngine/Core/CommandContext.cpp
+++ b/MiniEngine/Core/CommandContext.cpp
@@ -393,7 +393,7 @@ void CommandContext::TransitionResource(GpuResource& Resource, D3D12_RESOURCE_ST
 	else if (NewState == D3D12_RESOURCE_STATE_UNORDERED_ACCESS)
 		InsertUAVBarrier(Resource, FlushImmediate);
 
-	if (FlushImmediate || m_NumBarriersToFlush == 16)
+	if (m_NumBarriersToFlush != 0 && (FlushImmediate || m_NumBarriersToFlush == 16))
 	{
 		m_CommandList->ResourceBarrier(m_NumBarriersToFlush, m_ResourceBarrierBuffer);
 		m_NumBarriersToFlush = 0;
@@ -424,7 +424,7 @@ void CommandContext::BeginResourceTransition(GpuResource& Resource, D3D12_RESOUR
 		Resource.m_TransitioningState = NewState;
 	}
 
-	if (FlushImmediate || m_NumBarriersToFlush == 16)
+	if (m_NumBarriersToFlush != 0 && (FlushImmediate || m_NumBarriersToFlush == 16))
 	{
 		m_CommandList->ResourceBarrier(m_NumBarriersToFlush, m_ResourceBarrierBuffer);
 		m_NumBarriersToFlush = 0;


### PR DESCRIPTION
In some rare cases you may end up calling ResourceBarrier with 0 barriers which will result in

`D3D12 WARNING: ID3D12CommandList::ResourceBarrier: Called with 0 NumBarriers resulting in no-op function call. [ RESOURCE_MANIPULATION WARNING #954: RESOURCE_BARRIER_ZERO_BARRIERS]`
